### PR TITLE
Add configurable week/month/year periods to /level-stats

### DIFF
--- a/src/features/leveling/__tests__/activityEventAggregation.test.ts
+++ b/src/features/leveling/__tests__/activityEventAggregation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
     aggregateActivityTotals,
+    aggregateDailyIntoWeeklyBuckets,
     aggregateEventsByDate,
     fillActivityDateRange,
+    filterEventsByActivityDateRange,
     sumDailyActivity,
     sumEventXp,
 } from '../logic/activityEventAggregation';
@@ -125,6 +127,54 @@ describe('activityEventAggregation', () => {
                 makeEvent({ id: 2, occurredAt: new Date(), xpAmount: 25 }),
             ])
         ).toBe(40);
+    });
+
+    it('filters events to an inclusive activity-date range', () => {
+        const events = [
+            makeEvent({ id: 1, occurredAt: new Date('2026-05-19T12:00:00Z') }),
+            makeEvent({ id: 2, occurredAt: new Date('2026-05-20T12:00:00Z') }),
+            makeEvent({ id: 3, occurredAt: new Date('2026-05-27T12:00:00Z') }),
+        ];
+
+        expect(filterEventsByActivityDateRange(events, '2026-05-20', '2026-05-26')).toEqual([
+            events[1],
+        ]);
+    });
+
+    it('rolls daily buckets into weekly chart buckets', () => {
+        const dailyBuckets = fillActivityDateRange(
+            [
+                {
+                    activityDate: '2026-01-01',
+                    messageCount: 1,
+                    reactionCount: 0,
+                    photoUploadCount: 0,
+                },
+                {
+                    activityDate: '2026-01-08',
+                    messageCount: 2,
+                    reactionCount: 1,
+                    photoUploadCount: 0,
+                },
+            ],
+            '2026-01-01',
+            '2026-01-14'
+        );
+
+        expect(aggregateDailyIntoWeeklyBuckets(dailyBuckets)).toEqual([
+            {
+                activityDate: '2026-01-01',
+                messageCount: 1,
+                reactionCount: 0,
+                photoUploadCount: 0,
+            },
+            {
+                activityDate: '2026-01-08',
+                messageCount: 2,
+                reactionCount: 1,
+                photoUploadCount: 0,
+            },
+        ]);
     });
 
     it('aggregates raw events into lifetime totals', () => {

--- a/src/features/leveling/__tests__/renderStatsCard.test.ts
+++ b/src/features/leveling/__tests__/renderStatsCard.test.ts
@@ -40,10 +40,17 @@ function makeStatsCardInput() {
         recentActivity,
         totalActivity,
         recentEvents: [],
-        dailyActivity,
+        chartBuckets: dailyActivity,
     });
 
-    return { profile, progress: null, dailyActivity, metrics, displayName: 'Spicy Member' };
+    return {
+        profile,
+        progress: null,
+        activityChart: { buckets: dailyActivity, granularity: 'daily' as const },
+        statsPeriod: 'week' as const,
+        metrics,
+        displayName: 'Spicy Member',
+    };
 }
 
 describe('renderStatsCard', () => {

--- a/src/features/leveling/__tests__/statsCard.introspect.test.ts
+++ b/src/features/leveling/__tests__/statsCard.introspect.test.ts
@@ -3,7 +3,9 @@
  *
  *   pnpm test statsCard.introspect
  *
- * Writes `.jarvis/stats-card-preview.png` (open in your image viewer).
+ * Writes:
+ *   `.jarvis/stats-card-preview.png` (last week)
+ *   `.jarvis/stats-card-month-preview.png` (last month)
  */
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -14,9 +16,19 @@ import type { LevelingActivityTotals } from '../data/levelingActivityEventSchema
 import type { LevelingProgress } from '../data/levelingProgressSchema';
 import { renderStatsCard } from '../cards/statsCard/renderStatsCard';
 import { buildStatsCardMetrics } from '../cards/statsCard/statsCardMetrics';
+import {
+    fillActivityDateRange,
+    subtractActivityDays,
+    sumDailyActivity,
+} from '../logic/activityEventAggregation';
 import { buildUserLevelProfile } from '../logic/userLevelProfile';
+import { getStatsPeriodDays, resolveActivityChartGranularity, type StatsPeriod } from '../logic/statsPeriod';
 
-const PREVIEW_OUTPUT = join(process.cwd(), '.jarvis', 'stats-card-preview.png');
+const PREVIEW_DIR = join(process.cwd(), '.jarvis');
+const WEEK_PREVIEW_OUTPUT = join(PREVIEW_DIR, 'stats-card-preview.png');
+const MONTH_PREVIEW_OUTPUT = join(PREVIEW_DIR, 'stats-card-month-preview.png');
+
+const PREVIEW_NOW = new Date('2026-05-26T12:00:00Z');
 
 /** Edit this scenario to iterate on the stats card locally. */
 const PREVIEW_SCENARIO = {
@@ -84,38 +96,187 @@ const PREVIEW_SCENARIO = {
     ] satisfies LevelingActivityEvent[],
 };
 
+function formatUtcDateKey(date: Date): string {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function getPreviewDateRange(now: Date, periodDays: number): { startDate: string; endDate: string } {
+    const endDate = formatUtcDateKey(now);
+    const startDate = formatUtcDateKey(subtractActivityDays(now, periodDays - 1));
+    return { startDate, endDate };
+}
+
+function makeSyntheticDailyActivity(startDate: string, endDate: string): DailyActivityBucket[] {
+    const sparseBuckets: DailyActivityBucket[] = [];
+
+    for (const activityDate of iteratePreviewDates(startDate, endDate)) {
+        const dayIndex = sparseBuckets.length;
+        const weekend = dayIndex % 7 === 5 || dayIndex % 7 === 6;
+        const wave = Math.sin(dayIndex * 0.55) * 2.5;
+        const messageCount = Math.max(0, Math.round((weekend ? 1 : 4) + wave + (dayIndex % 4)));
+        const reactionCount = Math.max(0, Math.round(messageCount * 0.45 + (dayIndex % 3)));
+        const photoUploadCount = dayIndex % 9 === 0 ? 1 : 0;
+
+        if (messageCount > 0 || reactionCount > 0 || photoUploadCount > 0) {
+            sparseBuckets.push({ activityDate, messageCount, reactionCount, photoUploadCount });
+        }
+    }
+
+    return fillActivityDateRange(sparseBuckets, startDate, endDate);
+}
+
+function* iteratePreviewDates(startDate: string, endDate: string): Generator<string> {
+    const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+    const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+    const cursor = new Date(Date.UTC(startYear, startMonth - 1, startDay));
+    const end = new Date(Date.UTC(endYear, endMonth - 1, endDay));
+
+    while (cursor <= end) {
+        yield formatUtcDateKey(cursor);
+        cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+}
+
+function bucketsToRecentActivity(buckets: DailyActivityBucket[]): LevelingActivityTotals {
+    const summed = sumDailyActivity(buckets);
+    const eventCount = summed.messageCount + summed.reactionCount;
+    const totalXp = summed.messageCount * 16 + summed.reactionCount * 2 + summed.photoUploadCount * 12;
+
+    return {
+        activityDate: 'total',
+        messageCount: summed.messageCount,
+        reactionCount: summed.reactionCount,
+        photoUploadCount: summed.photoUploadCount,
+        totalXp,
+        eventCount,
+    };
+}
+
+async function writeStatsCardPreview(
+    outputPath: string,
+    input: {
+        displayName: string;
+        progress: LevelingProgress;
+        recentActivity: LevelingActivityTotals;
+        totalActivity: LevelingActivityTotals;
+        chartBuckets: DailyActivityBucket[];
+        statsPeriod: StatsPeriod;
+        recentEvents: LevelingActivityEvent[];
+        now: Date;
+    }
+): Promise<Buffer> {
+    const periodDays = getStatsPeriodDays(input.statsPeriod);
+    const profile = buildUserLevelProfile({
+        userId: input.progress.userId,
+        progress: input.progress,
+        recentActivity: input.recentActivity,
+        totalActivity: input.totalActivity,
+        recentPeriodDays: periodDays,
+        now: input.now,
+    });
+
+    const metrics = buildStatsCardMetrics({
+        progress: input.progress,
+        recentActivity: input.recentActivity,
+        totalActivity: input.totalActivity,
+        recentEvents: input.recentEvents,
+        chartBuckets: input.chartBuckets,
+        recentPeriodDays: periodDays,
+        now: input.now,
+    });
+
+    const png = await renderStatsCard({
+        profile,
+        progress: input.progress,
+        activityChart: {
+            buckets: input.chartBuckets,
+            granularity: resolveActivityChartGranularity(periodDays),
+        },
+        statsPeriod: input.statsPeriod,
+        metrics,
+        displayName: input.displayName,
+        avatarUrl: null,
+    });
+
+    await mkdir(PREVIEW_DIR, { recursive: true });
+    await writeFile(outputPath, png);
+
+    return png;
+}
+
 describe('stats card introspection', () => {
-    it('writes a PNG preview for local stats card tuning', async () => {
-        const profile = buildUserLevelProfile({
-            userId: PREVIEW_SCENARIO.progress.userId,
-            progress: PREVIEW_SCENARIO.progress,
-            recentActivity: PREVIEW_SCENARIO.recentActivity,
-            totalActivity: PREVIEW_SCENARIO.totalActivity,
-        });
-
-        const metrics = buildStatsCardMetrics({
-            progress: PREVIEW_SCENARIO.progress,
-            recentActivity: PREVIEW_SCENARIO.recentActivity,
-            totalActivity: PREVIEW_SCENARIO.totalActivity,
-            recentEvents: PREVIEW_SCENARIO.recentEvents,
-            dailyActivity: PREVIEW_SCENARIO.dailyActivity,
-            now: new Date('2026-05-26T12:00:00Z'),
-        });
-
-        const png = await renderStatsCard({
-            profile,
-            progress: PREVIEW_SCENARIO.progress,
-            dailyActivity: PREVIEW_SCENARIO.dailyActivity,
-            metrics,
+    it('writes a PNG preview for the last-week stats card', async () => {
+        const png = await writeStatsCardPreview(WEEK_PREVIEW_OUTPUT, {
             displayName: PREVIEW_SCENARIO.displayName,
-            avatarUrl: null,
+            progress: PREVIEW_SCENARIO.progress,
+            recentActivity: PREVIEW_SCENARIO.recentActivity,
+            totalActivity: PREVIEW_SCENARIO.totalActivity,
+            chartBuckets: PREVIEW_SCENARIO.dailyActivity,
+            statsPeriod: 'week',
+            recentEvents: PREVIEW_SCENARIO.recentEvents,
+            now: PREVIEW_NOW,
         });
 
-        await mkdir(join(process.cwd(), '.jarvis'), { recursive: true });
-        await writeFile(PREVIEW_OUTPUT, png);
+        console.log(`\nWeek stats card preview written to:\n  ${WEEK_PREVIEW_OUTPUT}\n`);
 
-        console.log(`\nStats card preview written to:\n  ${PREVIEW_OUTPUT}\n`);
+        expect(png.byteLength).toBeGreaterThan(1_000);
+        expect(png.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+    }, 30_000);
 
+    it('writes a PNG preview for the last-month stats card', async () => {
+        const periodDays = getStatsPeriodDays('month');
+        const { startDate, endDate } = getPreviewDateRange(PREVIEW_NOW, periodDays);
+        const chartBuckets = makeSyntheticDailyActivity(startDate, endDate);
+        const recentActivity = bucketsToRecentActivity(chartBuckets);
+
+        const png = await writeStatsCardPreview(MONTH_PREVIEW_OUTPUT, {
+            displayName: PREVIEW_SCENARIO.displayName,
+            progress: PREVIEW_SCENARIO.progress,
+            recentActivity,
+            totalActivity: PREVIEW_SCENARIO.totalActivity,
+            chartBuckets,
+            statsPeriod: 'month',
+            recentEvents: [
+                {
+                    id: 1,
+                    guildId: 'preview-guild',
+                    userId: 'preview-user',
+                    activityType: 'message',
+                    xpAmount: 18,
+                    messageLength: 142,
+                    photoBonus: false,
+                    occurredAt: new Date('2026-05-26T09:15:00Z'),
+                },
+                {
+                    id: 2,
+                    guildId: 'preview-guild',
+                    userId: 'preview-user',
+                    activityType: 'message',
+                    xpAmount: 22,
+                    messageLength: 228,
+                    photoBonus: true,
+                    occurredAt: new Date('2026-05-18T14:00:00Z'),
+                },
+                {
+                    id: 3,
+                    guildId: 'preview-guild',
+                    userId: 'preview-user',
+                    activityType: 'message',
+                    xpAmount: 15,
+                    messageLength: 96,
+                    photoBonus: false,
+                    occurredAt: new Date('2026-05-04T11:30:00Z'),
+                },
+            ],
+            now: PREVIEW_NOW,
+        });
+
+        console.log(`\nMonth stats card preview written to:\n  ${MONTH_PREVIEW_OUTPUT}\n`);
+
+        expect(chartBuckets).toHaveLength(30);
         expect(png.byteLength).toBeGreaterThan(1_000);
         expect(png.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
     }, 30_000);

--- a/src/features/leveling/__tests__/statsCard.test.ts
+++ b/src/features/leveling/__tests__/statsCard.test.ts
@@ -58,13 +58,14 @@ describe('buildStatsCardElement', () => {
             recentActivity,
             totalActivity,
             recentEvents: [],
-            dailyActivity,
+            chartBuckets: dailyActivity,
         });
 
         const element = buildStatsCardElement({
             profile,
             progress: null,
-            dailyActivity,
+            activityChart: { buckets: dailyActivity, granularity: 'daily' },
+            statsPeriod: 'week',
             metrics,
             displayName: 'Spicy Member',
             avatarDataUri: null,
@@ -92,13 +93,14 @@ describe('buildStatsCardElement', () => {
             recentActivity: makeTotals(),
             totalActivity: makeTotals(),
             recentEvents: [],
-            dailyActivity: [],
+            chartBuckets: [],
         });
 
         const element = buildStatsCardElement({
             profile,
             progress: null,
-            dailyActivity: [],
+            activityChart: { buckets: [], granularity: 'daily' },
+            statsPeriod: 'week',
             metrics,
             displayName: 'Quiet Member',
             avatarDataUri: null,

--- a/src/features/leveling/__tests__/statsCardMetrics.test.ts
+++ b/src/features/leveling/__tests__/statsCardMetrics.test.ts
@@ -58,7 +58,7 @@ describe('statsCardMetrics', () => {
             recentActivity: makeTotals({ messageCount: 8, reactionCount: 4, eventCount: 12 }),
             totalActivity: makeTotals({ messageCount: 50, eventCount: 80 }),
             recentEvents: [],
-            dailyActivity: [],
+            chartBuckets: [],
         });
 
         expect(metrics.activityStatus).toBe('active');
@@ -70,7 +70,7 @@ describe('statsCardMetrics', () => {
             recentActivity: makeTotals(),
             totalActivity: makeTotals({ messageCount: 50, eventCount: 80 }),
             recentEvents: [],
-            dailyActivity: [],
+            chartBuckets: [],
         });
 
         expect(metrics.activityStatus).toBe('dormant');
@@ -91,7 +91,7 @@ describe('statsCardMetrics', () => {
                 makeMessageEvent('2026-05-26T12:00:00Z', 40),
                 makeMessageEvent('2026-05-26T13:00:00Z', 80),
             ],
-            dailyActivity: [],
+            chartBuckets: [],
             recentPeriodDays: 7,
         });
 
@@ -108,5 +108,27 @@ describe('statsCardMetrics', () => {
 
         expect(formatRelativeTime(new Date('2026-05-26T11:30:00Z'), now)).toBe('30m ago');
         expect(formatActivityStatus('quiet')).toBe('Quiet');
+    });
+
+    it('scales active thresholds with the selected period length', () => {
+        const quietMonth = buildStatsCardMetrics({
+            progress: makeProgress(),
+            recentActivity: makeTotals({ messageCount: 15, eventCount: 40 }),
+            totalActivity: makeTotals({ messageCount: 50, eventCount: 80 }),
+            recentEvents: [],
+            chartBuckets: [],
+            recentPeriodDays: 30,
+        });
+        const activeMonth = buildStatsCardMetrics({
+            progress: makeProgress(),
+            recentActivity: makeTotals({ messageCount: 22, eventCount: 40 }),
+            totalActivity: makeTotals({ messageCount: 50, eventCount: 80 }),
+            recentEvents: [],
+            chartBuckets: [],
+            recentPeriodDays: 30,
+        });
+
+        expect(quietMonth.activityStatus).toBe('quiet');
+        expect(activeMonth.activityStatus).toBe('active');
     });
 });

--- a/src/features/leveling/__tests__/statsPeriod.test.ts
+++ b/src/features/leveling/__tests__/statsPeriod.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getStatsPeriodDays,
+    parseStatsPeriod,
+    resolveActivityChartGranularity,
+} from '../logic/statsPeriod';
+
+describe('statsPeriod', () => {
+    it('defaults unknown period values to week', () => {
+        expect(parseStatsPeriod(null)).toBe('week');
+        expect(parseStatsPeriod('invalid')).toBe('week');
+    });
+
+    it('maps period choices to day counts', () => {
+        expect(getStatsPeriodDays('week')).toBe(7);
+        expect(getStatsPeriodDays('month')).toBe(30);
+        expect(getStatsPeriodDays('year')).toBe(364);
+    });
+
+    it('uses daily chart buckets within the max bar count and weekly beyond it', () => {
+        expect(resolveActivityChartGranularity(7)).toBe('daily');
+        expect(resolveActivityChartGranularity(30)).toBe('daily');
+        expect(resolveActivityChartGranularity(52)).toBe('daily');
+        expect(resolveActivityChartGranularity(53)).toBe('weekly');
+        expect(resolveActivityChartGranularity(364)).toBe('weekly');
+    });
+});

--- a/src/features/leveling/cards/statsCard/buildStatsCardElement.ts
+++ b/src/features/leveling/cards/statsCard/buildStatsCardElement.ts
@@ -1,5 +1,7 @@
 import type { DailyActivityBucket } from '../../data/levelingActivityEventSchema';
 import type { UserLevelStats } from '../../logic/loadUserLevelStats';
+import { formatStatsPeriodChartLabel } from '../../logic/statsPeriod';
+import type { ActivityChartGranularity } from '../../logic/statsPeriod';
 import {
     formatActivityStatus,
     formatRelativeTime,
@@ -216,59 +218,121 @@ function buildPanelBox(children: SatoriChild): SatoriElement {
     });
 }
 
-function buildDailyChart(dailyActivity: DailyActivityBucket[], peakEvents: number): SatoriElement {
+function formatChartBucketLabel(
+    activityDate: string,
+    granularity: ActivityChartGranularity,
+    bucketIndex: number,
+    bucketCount: number
+): string {
+    if (granularity === 'weekly') {
+        const [year, month, day] = activityDate.split('-').map(Number);
+        const weekStart = new Date(Date.UTC(year, month - 1, day));
+        return formatShortDate(weekStart);
+    }
+
+    if (bucketCount > 14 && bucketIndex % 2 !== 0) {
+        return '';
+    }
+
+    return activityDate.slice(8);
+}
+
+function buildActivityChart(
+    buckets: DailyActivityBucket[],
+    peakEvents: number,
+    granularity: ActivityChartGranularity
+): SatoriElement {
     const barMaxHeight = STATS_CARD_CHART_BAR_MAX_HEIGHT;
-    const barWidth = STATS_CARD_CHART_BAR_WIDTH;
-    const chartHeight = barMaxHeight + 14;
+    const denseChart = buckets.length > 14;
+    const barWidth = denseChart
+        ? Math.max(4, Math.min(STATS_CARD_CHART_BAR_WIDTH, Math.floor(280 / buckets.length)))
+        : STATS_CARD_CHART_BAR_WIDTH;
+    const labelRowHeight = 14;
+    const chartGap = 4;
+    const chartHeight = barMaxHeight + chartGap + labelRowHeight;
+    const labelFontSize = denseChart ? 8 : 10;
+    const slotGap = denseChart ? 2 : 6;
 
     return el('div', {
         style: {
             display: 'flex',
             alignItems: 'flex-end',
             justifyContent: 'space-between',
-            gap: 6,
+            gap: slotGap,
             width: '100%',
             height: chartHeight,
             flexShrink: 0,
         },
-        children: dailyActivity.map((day) => {
-            const eventCount = day.messageCount + day.reactionCount;
-            const height =
-                peakEvents > 0 ? Math.max(4, Math.round((eventCount / peakEvents) * barMaxHeight)) : 4;
-            const dayLabel = day.activityDate.slice(8);
+        children: buckets.map((bucket, bucketIndex) => {
+            const eventCount = bucket.messageCount + bucket.reactionCount;
+            const barHeight =
+                peakEvents > 0
+                    ? Math.max(4, Math.round((eventCount / peakEvents) * barMaxHeight))
+                    : 4;
+            const spacerHeight = barMaxHeight - barHeight;
+            const bucketLabel = formatChartBucketLabel(
+                bucket.activityDate,
+                granularity,
+                bucketIndex,
+                buckets.length
+            );
 
             return el('div', {
                 style: {
                     display: 'flex',
                     flexDirection: 'column',
                     alignItems: 'center',
-                    justifyContent: 'flex-end',
-                    gap: 4,
+                    gap: chartGap,
                     flex: 1,
+                    minWidth: 0,
+                    height: chartHeight,
                 },
                 children: [
                     el('div', {
                         style: {
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
                             width: barWidth,
-                            height,
-                            borderRadius: 6,
-                            ...(eventCount > 0
-                                ? {
-                                      backgroundImage: `linear-gradient(180deg, ${STATS_CARD_COLORS.accentSoft}, ${STATS_CARD_COLORS.accent})`,
-                                  }
-                                : {
-                                      backgroundColor: STATS_CARD_COLORS.track,
-                                  }),
+                            height: barMaxHeight,
                         },
+                        children: [
+                            el('div', { style: { width: barWidth, height: spacerHeight } }),
+                            el('div', {
+                                style: {
+                                    width: barWidth,
+                                    height: barHeight,
+                                    borderRadius: denseChart ? 4 : 6,
+                                    ...(eventCount > 0
+                                        ? {
+                                              backgroundImage: `linear-gradient(180deg, ${STATS_CARD_COLORS.accentSoft}, ${STATS_CARD_COLORS.accent})`,
+                                          }
+                                        : {
+                                              backgroundColor: STATS_CARD_COLORS.track,
+                                          }),
+                                },
+                            }),
+                        ],
                     }),
                     el('div', {
                         style: {
-                            fontSize: 10,
-                            color: STATS_CARD_COLORS.textMuted,
-                            fontFamily: 'Inter',
-                            flexShrink: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: '100%',
+                            height: labelRowHeight,
                         },
-                        children: dayLabel,
+                        children: el('div', {
+                            style: {
+                                fontSize: labelFontSize,
+                                lineHeight: `${labelRowHeight}px`,
+                                color: STATS_CARD_COLORS.textMuted,
+                                fontFamily: 'Inter',
+                                whiteSpace: 'nowrap',
+                                textAlign: 'center',
+                            },
+                            children: bucketLabel || '\u00a0',
+                        }),
                     }),
                 ],
             });
@@ -405,8 +469,9 @@ function buildEmptyState(): SatoriElement {
 }
 
 function buildActiveBody(input: BuildStatsCardElementInput): SatoriElement {
-    const { profile, dailyActivity, metrics } = input;
-    const { recentActivity, recentPeriodDays } = profile;
+    const { profile, activityChart, statsPeriod, metrics } = input;
+    const { recentActivity } = profile;
+    const periodLabel = formatStatsPeriodChartLabel(statsPeriod);
 
     return el('div', {
         style: {
@@ -452,8 +517,12 @@ function buildActiveBody(input: BuildStatsCardElementInput): SatoriElement {
                             minWidth: 0,
                         },
                         children: buildPanelBox([
-                            buildSectionTitle(`Activity trend (${recentPeriodDays}d)`),
-                            buildDailyChart(dailyActivity, metrics.dailyPeakEvents),
+                            buildSectionTitle(`Activity trend (${periodLabel})`),
+                            buildActivityChart(
+                                activityChart.buckets,
+                                metrics.dailyPeakEvents,
+                                activityChart.granularity
+                            ),
                         ]),
                     }),
                     el('div', {

--- a/src/features/leveling/cards/statsCard/statsCardMetrics.ts
+++ b/src/features/leveling/cards/statsCard/statsCardMetrics.ts
@@ -27,14 +27,14 @@ export type BuildStatsCardMetricsInput = {
     recentActivity: LevelingActivityTotals;
     totalActivity: LevelingActivityTotals;
     recentEvents: ReadonlyArray<LevelingActivityEvent>;
-    dailyActivity: ReadonlyArray<DailyActivityBucket>;
+    chartBuckets: ReadonlyArray<DailyActivityBucket>;
     recentPeriodDays?: number;
     now?: Date;
 };
 
 export function buildStatsCardMetrics(input: BuildStatsCardMetricsInput): StatsCardMetrics {
     const recentPeriodDays = input.recentPeriodDays ?? LEVELING_RECENT_ACTIVITY_DAYS;
-    const { recentActivity, totalActivity, dailyActivity, recentEvents, progress } = input;
+    const { recentActivity, totalActivity, chartBuckets, recentEvents, progress } = input;
 
     const tenureDays = Math.max(1, computeTenureDays(progress, input.now ?? new Date()));
     const engagementTotal = recentActivity.messageCount + recentActivity.reactionCount;
@@ -46,13 +46,13 @@ export function buildStatsCardMetrics(input: BuildStatsCardMetricsInput): StatsC
             ? Math.round((recentActivity.photoUploadCount / recentActivity.messageCount) * 100)
             : 0;
 
-    const dailyPeakEvents = dailyActivity.reduce(
+    const dailyPeakEvents = chartBuckets.reduce(
         (peak, day) => Math.max(peak, day.messageCount + day.reactionCount),
         0
     );
 
     return {
-        activityStatus: resolveActivityStatus(recentActivity, totalActivity),
+        activityStatus: resolveActivityStatus(recentActivity, totalActivity, recentPeriodDays),
         lastActiveAt: getLastActiveAt(progress),
         memberSince: progress?.createdAt ? toDate(progress.createdAt) : null,
         tenureDays,
@@ -117,7 +117,8 @@ export function formatActivityStatus(status: ActivityStatus): string {
 
 function resolveActivityStatus(
     recentActivity: LevelingActivityTotals,
-    totalActivity: LevelingActivityTotals
+    totalActivity: LevelingActivityTotals,
+    recentPeriodDays: number
 ): ActivityStatus {
     if (totalActivity.eventCount === 0) {
         return 'none';
@@ -127,7 +128,11 @@ function resolveActivityStatus(
         return 'dormant';
     }
 
-    if (recentActivity.messageCount >= 5 || recentActivity.eventCount >= 12) {
+    const periodScale = recentPeriodDays / LEVELING_RECENT_ACTIVITY_DAYS;
+    const activeMessageThreshold = Math.max(1, Math.round(5 * periodScale));
+    const activeEventThreshold = Math.max(1, Math.round(12 * periodScale));
+
+    if (recentActivity.messageCount >= activeMessageThreshold || recentActivity.eventCount >= activeEventThreshold) {
         return 'active';
     }
 

--- a/src/features/leveling/commands/levelStatsCommand.ts
+++ b/src/features/leveling/commands/levelStatsCommand.ts
@@ -2,6 +2,7 @@ import { AttachmentBuilder, ChatInputCommandInteraction, SlashCommandBuilder } f
 import { commandError, commandSuccess } from '../../../features-system/commands';
 import { InteractionHandlerResult } from '../../../features-system/commands/types';
 import { loadUserLevelStats } from '../logic/loadUserLevelStats';
+import { parseStatsPeriod } from '../logic/statsPeriod';
 import { cardAvatarUrlFromUser } from '../cards/shared/cardAvatarUrl';
 import { renderStatsCard } from '../cards/statsCard/renderStatsCard';
 
@@ -12,6 +13,17 @@ export const levelStatsCommand = new SlashCommandBuilder()
     .setDescription('View leveling activity stats for a member')
     .addUserOption((option) =>
         option.setName('user').setDescription('Member to inspect (defaults to you)').setRequired(false)
+    )
+    .addStringOption((option) =>
+        option
+            .setName('period')
+            .setDescription('Activity window for stats and chart (default: last week)')
+            .setRequired(false)
+            .addChoices(
+                { name: 'Last week', value: 'week' },
+                { name: 'Last month', value: 'month' },
+                { name: 'Last year', value: 'year' }
+            )
     );
 
 export async function handleLevelStatsCommand(
@@ -27,7 +39,8 @@ export async function handleLevelStatsCommand(
     await interaction.deferReply({ ephemeral: true });
 
     try {
-        const stats = await loadUserLevelStats(interaction.guildId, targetUser.id);
+        const period = parseStatsPeriod(interaction.options.getString('period'));
+        const stats = await loadUserLevelStats(interaction.guildId, targetUser.id, { period });
         const cardPng = await renderStatsCard({
             ...stats,
             displayName: targetUser.displayName,

--- a/src/features/leveling/logic/activityEventAggregation.ts
+++ b/src/features/leveling/logic/activityEventAggregation.ts
@@ -121,6 +121,45 @@ export function subtractActivityDays(from: Date, days: number): Date {
     return result;
 }
 
+export function getActivityDateStart(dateKey: string): Date {
+    return parseActivityDate(dateKey);
+}
+
+export function filterEventsByActivityDateRange(
+    events: ReadonlyArray<LevelingActivityEvent>,
+    startDate: string,
+    endDate: string
+): LevelingActivityEvent[] {
+    return events.filter((event) => {
+        const activityDate = getActivityDateKey(toDate(event.occurredAt));
+        return activityDate >= startDate && activityDate <= endDate;
+    });
+}
+
+export function aggregateDailyIntoWeeklyBuckets(
+    dailyBuckets: ReadonlyArray<DailyActivityBucket>
+): DailyActivityBucket[] {
+    if (dailyBuckets.length === 0) {
+        return [];
+    }
+
+    const weeklyBuckets: DailyActivityBucket[] = [];
+
+    for (let index = 0; index < dailyBuckets.length; index += 7) {
+        const weekDays = dailyBuckets.slice(index, index + 7);
+        const totals = sumDailyActivity(weekDays);
+
+        weeklyBuckets.push({
+            activityDate: weekDays[0].activityDate,
+            messageCount: totals.messageCount,
+            reactionCount: totals.reactionCount,
+            photoUploadCount: totals.photoUploadCount,
+        });
+    }
+
+    return weeklyBuckets;
+}
+
 function toDate(value: Date | string): Date {
     return value instanceof Date ? value : new Date(value);
 }

--- a/src/features/leveling/logic/loadUserLevelStats.ts
+++ b/src/features/leveling/logic/loadUserLevelStats.ts
@@ -1,23 +1,43 @@
-import { LEVELING_RECENT_ACTIVITY_DAYS } from '../constants';
 import { levelingActivityEventRepo } from '../data/levelingActivityEventRepo';
 import { levelingProgressRepo } from '../data/levelingProgressRepo';
 import {
     aggregateActivityTotals,
+    aggregateDailyIntoWeeklyBuckets,
     aggregateEventsByDate,
     fillActivityDateRange,
+    filterEventsByActivityDateRange,
     getActivityDateKey,
+    getActivityDateStart,
     subtractActivityDays,
 } from './activityEventAggregation';
-import { buildUserLevelProfile, getRecentActivitySince, type UserLevelProfile } from './userLevelProfile';
+import { buildUserLevelProfile, type UserLevelProfile } from './userLevelProfile';
+import {
+    DEFAULT_STATS_PERIOD,
+    getStatsPeriodDays,
+    resolveActivityChartGranularity,
+    type ActivityChartGranularity,
+    type StatsPeriod,
+} from './statsPeriod';
 import { buildStatsCardMetrics, type StatsCardMetrics } from '../cards/statsCard/statsCardMetrics';
 import type { DailyActivityBucket } from '../data/levelingActivityEventSchema';
 import type { LevelingProgress } from '../data/levelingProgressSchema';
 
+export type ActivityChart = {
+    buckets: DailyActivityBucket[];
+    granularity: ActivityChartGranularity;
+};
+
 export type UserLevelStats = {
     profile: UserLevelProfile;
     progress: LevelingProgress | null;
-    dailyActivity: DailyActivityBucket[];
+    activityChart: ActivityChart;
+    statsPeriod: StatsPeriod;
     metrics: StatsCardMetrics;
+};
+
+export type LoadUserLevelStatsOptions = {
+    period?: StatsPeriod;
+    now?: Date;
 };
 
 function getRecentActivityDateRange(now: Date, days: number): { startDate: string; endDate: string } {
@@ -26,24 +46,54 @@ function getRecentActivityDateRange(now: Date, days: number): { startDate: strin
     return { startDate, endDate };
 }
 
-export async function loadUserLevelStats(guildId: string, userId: string): Promise<UserLevelStats> {
-    const since = getRecentActivitySince();
-    const { startDate, endDate } = getRecentActivityDateRange(new Date(), LEVELING_RECENT_ACTIVITY_DAYS);
+function resolveActivityChart(
+    dailyBuckets: DailyActivityBucket[],
+    periodDays: number
+): ActivityChart {
+    const granularity = resolveActivityChartGranularity(periodDays);
 
-    const [progress, recentEvents, totalActivity] = await Promise.all([
+    if (granularity === 'weekly') {
+        return {
+            buckets: aggregateDailyIntoWeeklyBuckets(dailyBuckets),
+            granularity,
+        };
+    }
+
+    return {
+        buckets: dailyBuckets,
+        granularity,
+    };
+}
+
+export async function loadUserLevelStats(
+    guildId: string,
+    userId: string,
+    options: LoadUserLevelStatsOptions = {}
+): Promise<UserLevelStats> {
+    const now = options.now ?? new Date();
+    const statsPeriod = options.period ?? DEFAULT_STATS_PERIOD;
+    const periodDays = getStatsPeriodDays(statsPeriod);
+    const { startDate, endDate } = getRecentActivityDateRange(now, periodDays);
+    const since = subtractActivityDays(getActivityDateStart(startDate), 1);
+
+    const [progress, recentEventsRaw, totalActivity] = await Promise.all([
         levelingProgressRepo.get(guildId, userId),
         levelingActivityEventRepo.getUserEvents(guildId, userId, { since }),
         levelingActivityEventRepo.getUserActivityTotals(guildId, userId),
     ]);
 
+    const recentEvents = filterEventsByActivityDateRange(recentEventsRaw, startDate, endDate);
     const recentActivity = aggregateActivityTotals(recentEvents);
     const dailyActivity = fillActivityDateRange(aggregateEventsByDate(recentEvents), startDate, endDate);
+    const activityChart = resolveActivityChart(dailyActivity, periodDays);
 
     const profile = buildUserLevelProfile({
         userId,
         progress,
         recentActivity,
         totalActivity,
+        recentPeriodDays: periodDays,
+        now,
     });
 
     const metrics = buildStatsCardMetrics({
@@ -51,13 +101,16 @@ export async function loadUserLevelStats(guildId: string, userId: string): Promi
         recentActivity,
         totalActivity,
         recentEvents,
-        dailyActivity,
+        chartBuckets: activityChart.buckets,
+        recentPeriodDays: periodDays,
+        now,
     });
 
     return {
         profile,
         progress,
-        dailyActivity,
+        activityChart,
+        statsPeriod,
         metrics,
     };
 }

--- a/src/features/leveling/logic/statsPeriod.ts
+++ b/src/features/leveling/logic/statsPeriod.ts
@@ -1,0 +1,42 @@
+/** Max bars on the stats activity chart before switching from daily to weekly buckets. */
+export const STATS_CHART_MAX_BARS = 52;
+
+export type StatsPeriod = 'week' | 'month' | 'year';
+
+export const DEFAULT_STATS_PERIOD: StatsPeriod = 'week';
+
+/** Year uses 52×7 days so weekly chart buckets stay within {@link STATS_CHART_MAX_BARS}. */
+export const STATS_PERIOD_DAYS: Record<StatsPeriod, number> = {
+    week: 7,
+    month: 30,
+    year: 52 * 7,
+} as const;
+
+export type ActivityChartGranularity = 'daily' | 'weekly';
+
+export function parseStatsPeriod(value: string | null): StatsPeriod {
+    if (value === 'month' || value === 'year') {
+        return value;
+    }
+
+    return DEFAULT_STATS_PERIOD;
+}
+
+export function getStatsPeriodDays(period: StatsPeriod): number {
+    return STATS_PERIOD_DAYS[period];
+}
+
+export function resolveActivityChartGranularity(periodDays: number): ActivityChartGranularity {
+    return periodDays <= STATS_CHART_MAX_BARS ? 'daily' : 'weekly';
+}
+
+export function formatStatsPeriodChartLabel(period: StatsPeriod): string {
+    switch (period) {
+        case 'week':
+            return '7d';
+        case 'month':
+            return '30d';
+        case 'year':
+            return '1y';
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `period` choice to `/level-stats` (`Last week`, `Last month`, `Last year`; default week).
- Drive hero stats, engagement mix, and activity chart from the selected window; scale activity-status thresholds with period length.
- Use daily chart buckets up to 52 days, then weekly buckets (year = 52×7 days for exactly 52 bars).
- Align DB/event filtering with the chart date range so totals match the bars.
- Fix dense month-chart bar baselines when alternating date labels are hidden.
- Extend `statsCard.introspect` to write week and month preview PNGs under `.jarvis/`.

## Test plan

- [x] `pnpm exec vitest run src/features/leveling/__tests__/statsPeriod.test.ts`
- [x] `pnpm exec vitest run src/features/leveling/__tests__/activityEventAggregation.test.ts`
- [x] `pnpm exec vitest run src/features/leveling/__tests__/statsCardMetrics.test.ts`
- [x] `pnpm exec vitest run src/features/leveling/__tests__/statsCard.test.ts`
- [x] `pnpm test statsCard.introspect` (week + month preview PNGs)
- [ ] Re-register slash commands and verify `/level-stats period:Last month` in Discord
