### PR TITLE
Fix voice-state fetch, relative lastActive, and dry-run voice XP

### DIFF
--- a/src/features/leveling/__tests__/belowThresholdCard.test.ts
+++ b/src/features/leveling/__tests__/belowThresholdCard.test.ts
@@ -63,6 +63,27 @@ describe('buildBelowThresholdCardElement', () => {
         expect(serialized).not.toContain('user-10');
     });
 
+    it('shows last active as relative time even after two weeks', () => {
+        const element = buildBelowThresholdCardElement({
+            guildName: 'Spicy Server',
+            report: {
+                filter: { level: 10, xp: null, scope: 'current' },
+                totalConsidered: 1,
+                entries: [],
+            },
+            cardEntries: [
+                makeEntry(1, {
+                    lastActiveAt: new Date('2026-03-17T12:00:00Z'),
+                }),
+            ],
+            now: new Date('2026-05-26T12:00:00Z'),
+        });
+
+        const serialized = JSON.stringify(element);
+        expect(serialized).toContain('70d ago');
+        expect(serialized).not.toContain('Mar 17');
+    });
+
     it('shows an empty state when nobody is below the bar', () => {
         const element = buildBelowThresholdCardElement({
             guildName: 'Spicy Server',

--- a/src/features/leveling/__tests__/levelingService.test.ts
+++ b/src/features/leveling/__tests__/levelingService.test.ts
@@ -4,6 +4,7 @@ import { getTotalXpForLevel } from '../logic/xpCalculator';
 const mockGetByGuildId = vi.fn();
 const mockGrantXp = vi.fn();
 const mockAnnounceLevelUp = vi.fn();
+const mockGetVoiceXpSettings = vi.fn();
 
 vi.mock('../data/levelingConfigRepo', () => ({
     levelingConfigRepo: {
@@ -21,11 +22,35 @@ vi.mock('../levelUpAnnouncer', () => ({
     announceLevelUp: (...args: unknown[]) => mockAnnounceLevelUp(...args),
 }));
 
+vi.mock('../logic/voiceXp', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../logic/voiceXp')>();
+    return {
+        ...actual,
+        getVoiceXpSettings: (...args: unknown[]) => mockGetVoiceXpSettings(...args),
+    };
+});
+
 import { LevelingService } from '../levelingService';
+import {
+    DEFAULT_VOICE_COOLDOWN_MS,
+    DEFAULT_VOICE_MIN_ELIGIBLE_SECONDS,
+    DEFAULT_VOICE_XP_PER_MINUTE,
+} from '../constants';
+
+function voiceXpSettings(overrides?: { voiceXpEnabled?: boolean }) {
+    return {
+        voiceXpPerMinute: DEFAULT_VOICE_XP_PER_MINUTE,
+        voiceMinEligibleSeconds: DEFAULT_VOICE_MIN_ELIGIBLE_SECONDS,
+        voiceCooldownMs: DEFAULT_VOICE_COOLDOWN_MS,
+        voiceXpEnabled: false,
+        ...overrides,
+    };
+}
 
 describe('LevelingService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockGetVoiceXpSettings.mockReturnValue(voiceXpSettings());
         mockGetByGuildId.mockResolvedValue({
             enabled: true,
             notificationChannelId: '999',
@@ -159,7 +184,51 @@ describe('LevelingService', () => {
         expect(mockGrantXp).not.toHaveBeenCalled();
     });
 
+    it('still tracks voice sessions when XP rewards are disabled', async () => {
+        const handleVoiceStateUpdate = vi.fn();
+        const reconcileGuild = vi.fn();
+        const service = new LevelingService({} as never, {
+            handleVoiceStateUpdate,
+            reconcileGuild,
+        } as never);
+
+        await service.handleVoiceStateUpdate(
+            { guild: { id: 'guild-1' }, member: { user: { bot: false } } } as never,
+            { guild: { id: 'guild-1' }, member: { user: { bot: false } } } as never
+        );
+        await service.reconcileGuild({ id: 'guild-1' } as never);
+
+        expect(handleVoiceStateUpdate).toHaveBeenCalled();
+        expect(reconcileGuild).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'guild-1' }),
+            expect.objectContaining({ allowStartSessions: true })
+        );
+        expect(mockGrantXp).not.toHaveBeenCalled();
+    });
+
+    it('does not grant voice XP when a session ends while rewards are disabled', async () => {
+        const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const service = new LevelingService({} as never);
+
+        await service.processVoiceSessionEnd({
+            guildId: 'guild-1',
+            userId: 'user-1',
+            channelId: 'vc-1',
+            eligibleMs: 180_000,
+            sessionStartedAt: new Date('2026-08-17T11:57:00.000Z'),
+            endedAt: new Date('2026-08-17T12:00:00.000Z'),
+        });
+
+        expect(mockGrantXp).not.toHaveBeenCalled();
+        expect(mockAnnounceLevelUp).not.toHaveBeenCalled();
+        expect(consoleInfo).toHaveBeenCalledWith(
+            expect.stringContaining('Skipping voice XP grant while rewards are disabled')
+        );
+        consoleInfo.mockRestore();
+    });
+
     it('grants voice XP and announces level-ups when a session ends', async () => {
+        mockGetVoiceXpSettings.mockReturnValue(voiceXpSettings({ voiceXpEnabled: true }));
         const levelThreeTotalXp = getTotalXpForLevel(3);
         mockGrantXp.mockResolvedValue({
             previousTotalXp: 0,

--- a/src/features/leveling/__tests__/statsCardMetrics.test.ts
+++ b/src/features/leveling/__tests__/statsCardMetrics.test.ts
@@ -117,6 +117,8 @@ describe('statsCardMetrics', () => {
         const now = new Date('2026-05-26T12:00:00Z');
 
         expect(formatRelativeTime(new Date('2026-05-26T11:30:00Z'), now)).toBe('30m ago');
+        expect(formatRelativeTime(new Date('2026-03-17T12:00:00Z'), now)).toBe('Mar 17');
+        expect(formatRelativeTime(new Date('2026-03-17T12:00:00Z'), now, { alwaysRelative: true })).toBe('70d ago');
         expect(formatActivityStatus('quiet')).toBe('Quiet');
     });
 

--- a/src/features/leveling/__tests__/voiceSessionCoordinator.test.ts
+++ b/src/features/leveling/__tests__/voiceSessionCoordinator.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { VoiceSessionRow } from '../data/levelingVoiceSessionRepo';
-import { createVoiceSessionCoordinator, type EndedVoiceSession } from '../logic/voiceSessionCoordinator';
+import {
+    createVoiceSessionCoordinator,
+    fetchLiveVoiceStates,
+    type EndedVoiceSession,
+} from '../logic/voiceSessionCoordinator';
 
 class InMemoryVoiceSessionRepo {
     private readonly sessions = new Map<string, VoiceSessionRow>();
@@ -112,5 +116,47 @@ describe('voiceSessionCoordinator', () => {
         expect(ended).toHaveLength(1);
         expect(ended[0]?.userId).toBe('user-b');
         expect(ended[0]?.eligibleMs).toBe(10 * 60_000);
+    });
+});
+
+describe('fetchLiveVoiceStates', () => {
+    it('uses the gateway cache and never calls fetch without a user snowflake', async () => {
+        const fetch = vi.fn();
+        const cached = {
+            id: '111111111111111111',
+            channelId: 'vc-1',
+            member: { user: { bot: false } },
+        };
+        const guild = {
+            voiceStates: {
+                cache: new Map([[cached.id, cached]]),
+                fetch,
+            },
+        };
+
+        const live = await fetchLiveVoiceStates(guild as never);
+
+        expect(fetch).not.toHaveBeenCalled();
+        expect(live.get(cached.id)).toBe(cached);
+    });
+
+    it('skips invalid refresh ids so Discord is not called with null', async () => {
+        const fetch = vi.fn().mockResolvedValue({
+            id: '222222222222222222',
+            channelId: 'vc-1',
+        });
+        const guild = {
+            voiceStates: {
+                cache: new Map(),
+                fetch,
+            },
+        };
+
+        await fetchLiveVoiceStates(guild as never, {
+            refreshUserIds: ['null', '', 'not-a-snowflake', '222222222222222222'],
+        });
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith('222222222222222222');
     });
 });

--- a/src/features/leveling/__tests__/voiceXp.test.ts
+++ b/src/features/leveling/__tests__/voiceXp.test.ts
@@ -41,7 +41,7 @@ describe('voiceXp', () => {
     });
 
     it('exposes code-default voice settings', () => {
-        expect(getVoiceXpSettings().voiceXpEnabled).toBe(true);
+        expect(getVoiceXpSettings().voiceXpEnabled).toBe(false);
         expect(getVoiceXpSettings().voiceXpPerMinute).toBe(DEFAULT_VOICE_XP_PER_MINUTE);
     });
 });

--- a/src/features/leveling/cards/belowThresholdCard/buildBelowThresholdCardElement.ts
+++ b/src/features/leveling/cards/belowThresholdCard/buildBelowThresholdCardElement.ts
@@ -236,7 +236,9 @@ function buildMemberCell(entry: BelowThresholdCardDisplayEntry): SatoriElement {
 }
 
 function buildTableRow(entry: BelowThresholdCardDisplayEntry, now: Date): SatoriElement {
-    const lastActive = entry.lastActiveAt ? formatRelativeTime(entry.lastActiveAt, now) : '—';
+    const lastActive = entry.lastActiveAt
+        ? formatRelativeTime(entry.lastActiveAt, now, { alwaysRelative: true })
+        : '—';
 
     return el('div', {
         style: {

--- a/src/features/leveling/cards/statsCard/statsCardMetrics.ts
+++ b/src/features/leveling/cards/statsCard/statsCardMetrics.ts
@@ -77,7 +77,11 @@ export function buildStatsCardMetrics(input: BuildStatsCardMetricsInput): StatsC
     };
 }
 
-export function formatRelativeTime(from: Date, now: Date = new Date()): string {
+export function formatRelativeTime(
+    from: Date,
+    now: Date = new Date(),
+    options?: { alwaysRelative?: boolean }
+): string {
     const diffMs = now.getTime() - from.getTime();
     if (diffMs < 0) {
         return 'just now';
@@ -97,7 +101,7 @@ export function formatRelativeTime(from: Date, now: Date = new Date()): string {
     }
 
     const days = Math.floor(hours / 24);
-    if (days < 14) {
+    if (options?.alwaysRelative || days < 14) {
         return `${days}d ago`;
     }
 

--- a/src/features/leveling/constants.ts
+++ b/src/features/leveling/constants.ts
@@ -36,7 +36,8 @@ export const DEFAULT_PHOTO_XP_BONUS_ENABLED = true;
 export const DEFAULT_VOICE_XP_PER_MINUTE = 12;
 export const DEFAULT_VOICE_MIN_ELIGIBLE_SECONDS = 60;
 export const DEFAULT_VOICE_COOLDOWN_MS = 60_000;
-export const DEFAULT_VOICE_XP_ENABLED = true;
+/** When false, voice sessions still track and reconcile; completed sessions are not granted XP. */
+export const DEFAULT_VOICE_XP_ENABLED = false;
 
 /** Periodic Discord voice-state sweep so missed leave events cannot leave sessions stuck. */
 export const VOICE_SESSION_RECONCILE_INTERVAL_MS = 5 * 60 * 1000;

--- a/src/features/leveling/levelingService.ts
+++ b/src/features/leveling/levelingService.ts
@@ -20,7 +20,6 @@ import { XpActivityType } from './logic/xpGrant';
 import { announceLevelUp } from './levelUpAnnouncer';
 import {
     createVoiceSessionCoordinator,
-    fetchLiveVoiceStates,
     VoiceSessionCoordinator,
     type EndedVoiceSession,
 } from './logic/voiceSessionCoordinator';
@@ -137,9 +136,7 @@ export class LevelingService {
         try {
             const config = await levelingConfigRepo.getByGuildId(guild.id);
             const allowStartSessions = isActiveConfig(config) && getVoiceXpSettings().voiceXpEnabled;
-            const voiceStates = await fetchLiveVoiceStates(guild);
             await this.voiceSessionCoordinator.reconcileGuild(guild, {
-                voiceStates,
                 allowStartSessions,
                 now,
             });

--- a/src/features/leveling/levelingService.ts
+++ b/src/features/leveling/levelingService.ts
@@ -122,7 +122,7 @@ export class LevelingService {
             }
 
             const config = await levelingConfigRepo.getByGuildId(guild.id);
-            if (!isActiveConfig(config) || !getVoiceXpSettings().voiceXpEnabled) {
+            if (!isActiveConfig(config)) {
                 return;
             }
 
@@ -135,7 +135,7 @@ export class LevelingService {
     async reconcileGuild(guild: Guild, now: Date = new Date()): Promise<void> {
         try {
             const config = await levelingConfigRepo.getByGuildId(guild.id);
-            const allowStartSessions = isActiveConfig(config) && getVoiceXpSettings().voiceXpEnabled;
+            const allowStartSessions = isActiveConfig(config);
             await this.voiceSessionCoordinator.reconcileGuild(guild, {
                 allowStartSessions,
                 now,
@@ -156,6 +156,13 @@ export class LevelingService {
     }
 
     async processVoiceSessionEnd(ended: EndedVoiceSession): Promise<void> {
+        if (!getVoiceXpSettings().voiceXpEnabled) {
+            console.info(
+                `[leveling] Skipping voice XP grant while rewards are disabled (guild=${ended.guildId} user=${ended.userId} eligibleMs=${ended.eligibleMs})`
+            );
+            return;
+        }
+
         const config = await levelingConfigRepo.getByGuildId(ended.guildId);
         const { xpAmount, eligibleSeconds } = calculateVoiceXpFromEligibleMs(ended.eligibleMs);
         const grantedAt = ended.endedAt;

--- a/src/features/leveling/logic/voiceSessionCoordinator.ts
+++ b/src/features/leveling/logic/voiceSessionCoordinator.ts
@@ -1,4 +1,4 @@
-import type { Collection, Guild, VoiceState } from 'discord.js';
+import { DiscordAPIError, type Collection, type Guild, type VoiceState } from 'discord.js';
 import type { LevelingVoiceSessionRepo } from '../data/levelingVoiceSessionRepo';
 import {
     planGuildReconciliation,
@@ -65,10 +65,14 @@ export class VoiceSessionCoordinator {
         }
     ): Promise<void> {
         const now = options?.now ?? this.now();
-        const voiceStates = options?.voiceStates ?? (await fetchLiveVoiceStates(guild));
+        const sessions = await this.voiceSessionRepo.listByGuild(guild.id);
+        const voiceStates =
+            options?.voiceStates ??
+            (await fetchLiveVoiceStates(guild, {
+                refreshUserIds: sessions.map((session) => session.userId),
+            }));
         const liveMembers = collectLiveNonBotMembers(voiceStates);
         const occupancyByChannel = buildOccupancyByChannel(liveMembers);
-        const sessions = await this.voiceSessionRepo.listByGuild(guild.id);
         const events = planGuildReconciliation({
             guildId: guild.id,
             sessions,
@@ -127,21 +131,41 @@ export function createVoiceSessionCoordinator(
     return new VoiceSessionCoordinator(dependencies);
 }
 
-export async function fetchLiveVoiceStates(guild: Guild): Promise<ReadonlyMap<string, VoiceState>> {
-    try {
-        const manager = guild.voiceStates as {
-            fetch: (user?: unknown) => Promise<unknown>;
-            cache: ReadonlyMap<string, VoiceState>;
-        };
-        const fetched = await manager.fetch();
-        if (isVoiceStateMap(fetched)) {
-            return fetched;
+const DISCORD_SNOWFLAKE_PATTERN = /^\d{17,20}$/;
+const UNKNOWN_VOICE_STATE_ERROR_CODE = 10065;
+
+/**
+ * discord.js `VoiceStateManager.fetch()` requires a user snowflake. A no-arg call
+ * hits `GET /guilds/{id}/voice-states/null` and Discord rejects it (50035).
+ * Guild voice state is already in the gateway cache (`GuildVoiceStates` intent).
+ * Open-session user IDs are confirmed per-user so missed leaves can still be caught.
+ */
+export async function fetchLiveVoiceStates(
+    guild: Guild,
+    options?: { refreshUserIds?: ReadonlyArray<string> }
+): Promise<ReadonlyMap<string, VoiceState>> {
+    const live = new Map(guild.voiceStates.cache);
+
+    for (const userId of options?.refreshUserIds ?? []) {
+        if (!DISCORD_SNOWFLAKE_PATTERN.test(userId)) {
+            continue;
         }
-        return manager.cache;
-    } catch (error) {
-        console.warn('[leveling] Failed to fetch guild voice states; using cache:', error);
-        return guild.voiceStates.cache;
+
+        try {
+            const state = await guild.voiceStates.fetch(userId);
+            if (state.channelId) {
+                live.set(state.id, state);
+            } else {
+                live.delete(userId);
+            }
+        } catch (error) {
+            if (isMissingVoiceStateError(error)) {
+                live.delete(userId);
+            }
+        }
     }
+
+    return live;
 }
 
 function collectLiveNonBotMembers(
@@ -170,6 +194,10 @@ function buildOccupancyByChannel(
     return occupancy;
 }
 
-function isVoiceStateMap(value: unknown): value is ReadonlyMap<string, VoiceState> {
-    return !!value && typeof value === 'object' && typeof (value as Map<string, VoiceState>).values === 'function';
+function isMissingVoiceStateError(error: unknown): boolean {
+    if (!(error instanceof DiscordAPIError)) {
+        return false;
+    }
+
+    return error.status === 404 || error.code === UNKNOWN_VOICE_STATE_ERROR_CODE;
 }

--- a/src/features/leveling/readme.md
+++ b/src/features/leveling/readme.md
@@ -25,7 +25,7 @@ Reaction XP, photo bonus, message XP ranges, cooldowns, and voice XP rates are t
 - Message XP: keyframed log curve — **8 XP @ 5 chars**, **25 XP @ 300 chars**, **50 XP cap @ 3,000 chars**; 20s cooldown
 - Reaction XP: 1–2 (random), 180s cooldown
 - Photo bonus: 10–20 extra XP on image uploads (when enabled)
-- Voice XP: **12 XP per full eligible minute** in a voice/video channel with at least one other non-bot; 60s minimum eligible time; 60s cooldown between session grants. Mute, deafen, and AFK channels do not change eligibility.
+- Voice XP: **12 XP per full eligible minute** in a voice/video channel with at least one other non-bot; 60s minimum eligible time; 60s cooldown between session grants. Mute, deafen, and AFK channels do not change eligibility. **Rewards are currently off** (`DEFAULT_VOICE_XP_ENABLED`) so sessions still track and reconcile without granting XP.
 
 Tune anchors in `MESSAGE_XP_KEYFRAMES` in [`constants.ts`](constants.ts). Empty text still uses the configured min (15 XP) for attachment-only posts. Photo bonus stacks on top of message XP.
 
@@ -43,7 +43,7 @@ A `VoiceStateUpdate` handler is the primary input. On ready, and every 5 minutes
 
 Bot restarts preserve in-flight eligible time via the transient table; Discord remains the source of truth for who is actually connected.
 
-Voice XP is isolated from the rest of leveling. A failure in the voice coordinator, session table, sweep, or voice grant is logged and contained — message and reaction XP keep writing. Voice session rows are only deleted after a successful session-end grant so a failed grant can retry on the next leave/reconcile.
+Voice XP is isolated from the rest of leveling. A failure in the voice coordinator, session table, sweep, or voice grant is logged and contained — message and reaction XP keep writing. Voice session rows are only deleted after a successful session-end grant so a failed grant can retry on the next leave/reconcile. While `DEFAULT_VOICE_XP_ENABLED` is false, session-end skips the grant (no XP, progress, or activity event) and still deletes the transient row so tracking can keep running.
 
 ## Activity history
 

--- a/src/features/leveling/readme.md
+++ b/src/features/leveling/readme.md
@@ -39,7 +39,7 @@ Voice XP uses a small state machine reconciled against live Discord voice state:
 - **Permanent** `leveling_activity_events` rows record each completed session (`voice_eligible_seconds`, start/end, channel, eligibility rule) so XP can be recalculated later if the formula changes.
 - `leveling_progress` counters (`voice_session_count`, `total_voice_seconds`) are derived and can be rebuilt from events.
 
-A `VoiceStateUpdate` handler is the primary input. On ready, and every 5 minutes, the bot fetches guild voice states from Discord and reconciles open rows (orphans, missing sessions, channel mismatches, occupancy drift). Missed leave events cannot leave a session stuck accruing forever.
+A `VoiceStateUpdate` handler is the primary input. On ready, and every 5 minutes, the bot reconciles open rows against the gateway voice-state cache (`GuildVoiceStates` intent) and confirms each open-session user with a per-user fetch. discord.js cannot bulk-fetch guild voice states; a no-arg `voiceStates.fetch()` would call `/voice-states/null` and Discord would reject it. Missed leave events cannot leave a session stuck accruing forever.
 
 Bot restarts preserve in-flight eligible time via the transient table; Discord remains the source of truth for who is actually connected.
 


### PR DESCRIPTION
## What
- Stop calling `guild.voiceStates.fetch()` with no user id during voice XP reconcile. Use the gateway voice-state cache, and only fetch real open-session snowflakes.
- Show `/level-report` last active as relative time (`70d ago`) instead of a calendar date after two weeks.
- Keep voice session tracking and reconcile running, but do not grant voice XP yet (`DEFAULT_VOICE_XP_ENABLED = false`).

## Why
discord.js `VoiceStateManager.fetch` always fetches one member. A no-arg call became `GET /guilds/{id}/voice-states/null`, which Discord rejected with 50035 on every startup/sweep. Reconcile already fell back to cache, so XP still ran, but the API error was noisy and wrong.

The below-threshold card reused stats-card relative time, which switches to a short date after 14 days. Staff need inactivity at a glance, not a calendar date.

Voice XP rewards stay off so we can watch joins, leaves, and reconcile in production before anyone earns XP from voice.

## How tested
- `pnpm exec vitest run src/features/leveling/__tests__/voiceSessionCoordinator.test.ts src/features/leveling/__tests__/voiceSessionReconciliation.test.ts src/features/leveling/__tests__/levelingService.test.ts`
- `pnpm exec vitest run src/features/leveling/__tests__/belowThresholdCard.test.ts src/features/leveling/__tests__/statsCardMetrics.test.ts src/features/leveling/__tests__/voiceXp.test.ts`
